### PR TITLE
ci(publish): adds publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ['Node.js CI']
     types: [completed]
-    branches: [master]
+    branches: [main]
 
 jobs:
   publish-new-version:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: 'Publish to NPM'
+
+on:
+  workflow_run:
+    workflows: ['Node.js CI']
+    types: [completed]
+    branches: [master]
+
+jobs:
+  publish-new-version:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: git setup
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          registry-url: 'https://registry.npmjs.org'
+      - name: npm install
+        run: npm ci
+
+      - name: Should release
+        id: should_release
+        continue-on-error: true
+        run: npm run should-release -- -v
+
+      - name: No release
+        if: steps.should_release.outcome != 'success'
+        run: echo "No release required. Skipping publishing."
+
+      - name: Version bump
+        if: steps.should_release.outcome == 'success'
+        run: npm run release
+
+      - name: Publish to NPM
+        if: steps.should_release.outcome == 'success'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Push commits to GitHub
+        if: steps.should_release.outcome == 'success'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "should-release": "node ./cli.js",
     "release": "standard-version"
   },
   "keywords": [


### PR DESCRIPTION
Adds the publish github action. Note that the NPM_TOKEN must be set in
conjunction with this change.
